### PR TITLE
Alert.js as a stateless component

### DIFF
--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,9 +1,7 @@
 import React from 'react';
 
-const Alert = () => (
+export const Alert = () => (
   <div className="alert alert-warning" role="alert" style={{"marginBottom": 0}}>
   <strong>Atenção!</strong> Estamos em fase de testes. Conheça as melhorias previstas e envie sugestões <a href="https://docs.google.com/forms/d/e/1FAIpQLSdt8YXI3i7RdolEMh-TX1oes5zGpSnbE3Sy3-ioVLJTqvgGVQ/viewform" taget="_blank" style={{"textDecoration": "underline"}}>aqui</a>.
   </div>
 );
-
-export { Alert };

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,11 +1,9 @@
 import React from 'react';
 
-export class Alert extends React.Component {
-  render() {
-    return (
-      <div className="alert alert-warning" role="alert" style={{"marginBottom": 0}}>
-        <strong>Atenção!</strong> Estamos em fase de testes. Conheça as melhorias previstas e envie sugestões <a href="https://docs.google.com/forms/d/e/1FAIpQLSdt8YXI3i7RdolEMh-TX1oes5zGpSnbE3Sy3-ioVLJTqvgGVQ/viewform" taget="_blank" style={{"textDecoration": "underline"}}>aqui</a>.
-      </div>
-    )
-  }
-}
+const Alert = () => (
+  <div className="alert alert-warning" role="alert" style={{"marginBottom": 0}}>
+  <strong>Atenção!</strong> Estamos em fase de testes. Conheça as melhorias previstas e envie sugestões <a href="https://docs.google.com/forms/d/e/1FAIpQLSdt8YXI3i7RdolEMh-TX1oes5zGpSnbE3Sy3-ioVLJTqvgGVQ/viewform" taget="_blank" style={{"textDecoration": "underline"}}>aqui</a>.
+  </div>
+);
+
+export { Alert };


### PR DESCRIPTION
As https://github.com/prefeiturasp/SME-FilaDaCreche/issues/6 suggests, we want to convert the stateful components into stateless components whenever possible. This accomplishes it for `Alert.js`.

Both before and after the change, this component looks like this when used:
![screenshot from 2018-08-23 18-50-32](https://user-images.githubusercontent.com/3386440/44553901-70909a00-a705-11e8-9384-c6a10cec2a95.png)
