### PR TITLE
ContinueButton as a stateless component

### DIFF
--- a/src/components/ContinueButton.js
+++ b/src/components/ContinueButton.js
@@ -1,20 +1,15 @@
 import React from 'react'
 import { BrowserRouter as Router, Route, Link } from 'react-router-dom';
 import { DefaultButton } from "./DefaultButton";
+import PropTypes from 'prop-types';
 
-export class ContinueButton extends React.Component {
-  handleClick = () => {
-    // alert(this.props.link);
-  }
+export const ContinueButton = (props) => (
+  <Link to={{pathname: props.link}}>
+    <DefaultButton title={props.title} subtitle={props.subtitle} />
+  </Link>
+);
 
-  render() {
-    return (
-      <Link to={{
-        pathname: this.props.link,
-        state: this.props.state
-      }}>
-        <DefaultButton title={this.props.title} subtitle={this.props.subtitle} onClick={this.handleClick} />
-      </Link>
-    );
-  }
-}
+ContinueButton.propTypes = {
+  link: PropTypes.string,
+  subtitle: PropTypes.string
+};


### PR DESCRIPTION
Part of #6. This applies these changes:
- Refactors it as a stateless component
- Cleans up the unused `handleClick`
- Types the props with `PropTypes`
- Removes unused `state` prop