### PR TITLE
Remove título "CRECHE" da página de resultados

### DIFF
--- a/src/configs/Strings.js
+++ b/src/configs/Strings.js
@@ -99,8 +99,7 @@ export default {
     month_of_birth: "Mês de nascimento",
     year_of_birth: "Ano de nascimento",
     phone: "Telefone",
-    meters: "metros",
-    daycare: "Creche"
+    meters: "metros"
   },
   routes: {
     privacy: "/privacidade",

--- a/src/containers/Results/SchoolList.js
+++ b/src/containers/Results/SchoolList.js
@@ -47,11 +47,6 @@ export class SchoolList extends React.Component {
     return (
       <div>
         <div className="school-list">
-          <div className="row school-list-header">
-            <div className="col-xs-8">
-              <h5>{STRINGS.messages.daycare}</h5>
-            </div>
-          </div>
           {this.generateSchoolList(this.state.schoolListPaginated)}
           <div className="row margin-bottom-sm">
             {paginate && <Link to="#" >


### PR DESCRIPTION
Parte da issue #34. A string `message.daycare` fica inutilizada depois disso, removi.