### PR TITLE
Altera título da página de resultados

### DIFF
--- a/src/configs/Strings.js
+++ b/src/configs/Strings.js
@@ -34,7 +34,7 @@ export default {
       return `Há ${waitListTotal} crianças na fila do ${groupName} a serem distribuídas nas ${numberOfSchools} creches perto de ${address}.`
     },
     title_wait_message: function (waitListTotal, numberOfSchools) {
-      return `${waitListTotal} crianças na fila de espera destas ${numberOfSchools} creches`;
+      return `Há ${waitListTotal} crianças na fila de espera destas ${numberOfSchools} creches`;
     },
     see_list_below: "Veja abaixo a lista das creches num raio de 2 quilômetros.",
     data_updated_at: function (dateString) {

--- a/src/configs/Strings.js
+++ b/src/configs/Strings.js
@@ -33,6 +33,9 @@ export default {
     total_wait_message: function (waitListTotal, groupName, numberOfSchools, address) {
       return `Há ${waitListTotal} crianças na fila do ${groupName} a serem distribuídas nas ${numberOfSchools} creches perto de ${address}.`
     },
+    title_wait_message: function (waitListTotal, numberOfSchools) {
+      return `${waitListTotal} crianças na fila de espera destas ${numberOfSchools} creches`;
+    },
     see_list_below: "Veja abaixo a lista das creches num raio de 2 quilômetros.",
     data_updated_at: function (dateString) {
       let formattedDate = new Date(dateString).toLocaleDateString('pt-BR', {year: 'numeric', month: 'numeric', day: 'numeric', hour: '2-digit', minute:'2-digit'});

--- a/src/containers/Results/Results.js
+++ b/src/containers/Results/Results.js
@@ -67,8 +67,8 @@ export class Results extends React.Component {
           title={STRINGS.actions.loading_results}
         />}
         {this.state.waitListLoaded && <Banner
-          title={STRINGS.results.total_wait_message(waitListTotal, this.state.groupName, numberOfSchools, this.state.geocodedAddress)}
-          paragraphs={[STRINGS.results.see_list_below]}
+          title={STRINGS.results.title_wait_message(waitListTotal, numberOfSchools)}
+          paragraphs={[STRINGS.results.total_wait_message(waitListTotal, this.state.groupName, numberOfSchools, this.state.geocodedAddress), STRINGS.results.see_list_below]}
         />}
         {this.state.waitListLoaded && <SchoolList schools={schoolsNearby} groupName={this.state.groupName} groupCode={this.state.groupCode} updatedAtMsg={updatedAtMsg} />}
         <Spacer classSize="spacer-sm" />


### PR DESCRIPTION
Parte da issue #34. O título da página de resultados fica assim:
![screenshot from 2018-09-03 22-06-49](https://user-images.githubusercontent.com/3386440/45004773-b97a0580-afc5-11e8-93ad-4f44be9eaaa6.png)
