### PR TITLE
Reposiciona data de atualização na página de resultados

### DIFF
--- a/src/configs/Strings.js
+++ b/src/configs/Strings.js
@@ -30,17 +30,14 @@ export default {
     paragraphs: ["Vou procurar creches que fiquem até 2 quilômetros de distância do seu endereço."]
   },
   results: {
-    total_wait_message: function (waitListTotal, groupName, numberOfSchools, address) {
-      return `Há ${waitListTotal} crianças na fila do ${groupName} a serem distribuídas nas ${numberOfSchools} creches perto de ${address}.`
+    total_wait_message: function (waitListTotal, groupName, numberOfSchools, address, updatedAt) {
+      const fomattedDate = new Date(updatedAt).toLocaleDateString('pt-BR', {year: 'numeric', month: 'numeric', day: 'numeric', hour: '2-digit', minute:'2-digit'});
+      return `Há ${waitListTotal} crianças na fila do ${groupName} a serem distribuídas nas ${numberOfSchools} creches perto de ${address}. Estes dados foram atualizados em ${fomattedDate}.`;
     },
     title_wait_message: function (waitListTotal, numberOfSchools) {
       return `${waitListTotal} crianças na fila de espera destas ${numberOfSchools} creches`;
     },
-    see_list_below: "Veja abaixo a lista das creches num raio de 2 quilômetros.",
-    data_updated_at: function (dateString) {
-      let formattedDate = new Date(dateString).toLocaleDateString('pt-BR', {year: 'numeric', month: 'numeric', day: 'numeric', hour: '2-digit', minute:'2-digit'});
-      return `* Dados atualizados em ${formattedDate}`;
-    }
+    see_list_below: "Veja abaixo a lista das creches num raio de 2 quilômetros."
   },
   school_list_explanation: {
     paragraphs: [

--- a/src/configs/Strings.js
+++ b/src/configs/Strings.js
@@ -33,6 +33,9 @@ export default {
     total_wait_message: function (waitListTotal, groupName, numberOfSchools, address) {
       return `Há ${waitListTotal} crianças na fila do ${groupName} a serem distribuídas nas ${numberOfSchools} creches perto de ${address}.`
     },
+    title_wait_message: function (waitListTotal, numberOfSchools) {
+      return `${waitListTotal} crianças na fila de espera destas ${numberOfSchools} creches`;
+    },
     see_list_below: "Veja abaixo a lista das creches num raio de 2 quilômetros.",
     data_updated_at: function (dateString) {
       let formattedDate = new Date(dateString).toLocaleDateString('pt-BR', {year: 'numeric', month: 'numeric', day: 'numeric', hour: '2-digit', minute:'2-digit'});

--- a/src/containers/Results/Results.js
+++ b/src/containers/Results/Results.js
@@ -67,8 +67,8 @@ export class Results extends React.Component {
           title={STRINGS.actions.loading_results}
         />}
         {this.state.waitListLoaded && <Banner
-          title={STRINGS.results.total_wait_message(waitListTotal, this.state.groupName, numberOfSchools, this.state.geocodedAddress)}
-          paragraphs={[STRINGS.results.see_list_below]}
+          title={STRINGS.results.title_wait_message(waitListTotal, numberOfSchools)}
+          paragraphs={[STRINGS.results.total_wait_message(waitListTotal, this.state.groupName, numberOfSchools, this.state.geocodedAddress), STRINGS.results.see_list_below]}
         />}
         {this.state.waitListLoaded && <SchoolList schools={schoolsNearby} groupName={this.state.groupName} groupCode={this.state.groupCode} updatedAtMsg={updatedAtMsg} />}
         <Spacer classSize="spacer-sm" />

--- a/src/containers/Results/Results.js
+++ b/src/containers/Results/Results.js
@@ -59,7 +59,6 @@ export class Results extends React.Component {
     const schoolsNearby = this.state.schoolsNearby ? this.state.schoolsNearby : false;
     const numberOfSchools = this.state.schoolsNearby ? this.state.schoolsNearby.length : false;
     const waitListTotal = this.state.waitListTotal ? this.state.waitListTotal : false;
-    const updatedAtMsg = this.state.waitListUpdatedAt ? STRINGS.results.data_updated_at(this.state.waitListUpdatedAt) : false;
     return (
       <div>
         <BackButton />
@@ -68,10 +67,9 @@ export class Results extends React.Component {
         />}
         {this.state.waitListLoaded && <Banner
           title={STRINGS.results.title_wait_message(waitListTotal, numberOfSchools)}
-          paragraphs={[STRINGS.results.total_wait_message(waitListTotal, this.state.groupName, numberOfSchools, this.state.geocodedAddress), STRINGS.results.see_list_below]}
+          paragraphs={[STRINGS.results.total_wait_message(waitListTotal, this.state.groupName, numberOfSchools, this.state.geocodedAddress, this.state.waitListUpdatedAt), STRINGS.results.see_list_below]}
         />}
-        {this.state.waitListLoaded && <SchoolList schools={schoolsNearby} groupName={this.state.groupName} groupCode={this.state.groupCode} updatedAtMsg={updatedAtMsg} />}
-        <Spacer classSize="spacer-sm" />
+        {this.state.waitListLoaded && <SchoolList schools={schoolsNearby} groupName={this.state.groupName} groupCode={this.state.groupCode} />}
         {this.state.waitListLoaded && <Banner
           title={STRINGS.actions.can_do}
         />}

--- a/src/containers/Results/SchoolList.js
+++ b/src/containers/Results/SchoolList.js
@@ -53,7 +53,7 @@ export class SchoolList extends React.Component {
             </div>
           </div>
           {this.generateSchoolList(this.state.schoolListPaginated)}
-          <div className="row margin-bottom-sm">
+          <div className="row">
             {paginate && <Link to="#" >
               <DefaultButton title={STRINGS.actions.see_more} onClick={this.handleSeeMore} />
             </Link>}

--- a/src/containers/Results/SchoolList.js
+++ b/src/containers/Results/SchoolList.js
@@ -58,7 +58,6 @@ export class SchoolList extends React.Component {
               <DefaultButton title={STRINGS.actions.see_more} onClick={this.handleSeeMore} />
             </Link>}
           </div>
-          <p>{this.props.updatedAtMsg}</p>
         </div>
       </div>
     )


### PR DESCRIPTION
Depende do Pull Request #37! É parte da issue #34.

Isso aqui
![screenshot from 2018-09-03 22-12-18](https://user-images.githubusercontent.com/3386440/45004870-7d937000-afc6-11e8-9267-2bfa2d0456bf.png)
vai pro título
![screenshot from 2018-09-03 22-13-01](https://user-images.githubusercontent.com/3386440/45004877-900da980-afc6-11e8-973e-232d1c0cea19.png)