### PR TITLE
Testes e bugfix em utils/toTitleCase

### DIFF
--- a/src/utils/toTitleCase.js
+++ b/src/utils/toTitleCase.js
@@ -1,3 +1,3 @@
 export default function toTitleCase(str) {
-  return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+  return str.replace(/\S+/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
 };

--- a/src/utils/toTitleCase.test.js
+++ b/src/utils/toTitleCase.test.js
@@ -1,0 +1,20 @@
+import toTitleCase from './toTitleCase';
+
+it('Converts words to title case', () => {
+  expect(toTitleCase("Beterraba")).toEqual("Beterraba");
+  expect(toTitleCase("índio")).toEqual("Índio");
+  expect(toTitleCase("maÇãs")).toEqual("Maçãs");
+  expect(toTitleCase("ÔNIBUS")).toEqual("Ônibus");
+  expect(toTitleCase("NúM3ros")).toEqual("Núm3ros");
+});
+
+it('Converts every word in some text to title case', () => {
+  expect(toTitleCase("Space separated.")).toEqual("Space Separated.");
+  expect(toTitleCase("What about commas, dots? That kind'o stuff.")).toEqual("What About Commas, Dots? That Kind'o Stuff.");
+  expect(toTitleCase("What.AbOut.missing spaces?")).toEqual("What.about.missing Spaces?");
+});
+
+it("Doesn't crash on corner cases", () => {
+  expect(toTitleCase("")).toEqual("");
+  expect(toTitleCase(".,.")).toEqual(".,.");
+});


### PR DESCRIPTION
Parte da issue #8.

Na explicação do commit 27d504e, eu sugeri que mudássemos o comportamento da função `toTitleCase` dizendo que na produção não tinha problema. Eu achei um caso onde o bug acontece em produção, pelo menos pra mim. No resultado [dessa busca](http://filadacreche.sme.prefeitura.sp.gov.br/#/resultados/28/-46.6219782/-23.4805037/Av.%20%C3%81gua%20Fria,%20S%C3%A3o%20Paulo%20-%20SP,%20Brasil), um endereço de creche fica mal formatado após passar pela função `toTitleCase`, como mostra o print:
![screenshot from 2018-09-08 15-24-09](https://user-images.githubusercontent.com/3386440/45257382-ed657a00-b37b-11e8-9d25-4e5a81344539.png)
Após a mudança, o bug é corrigido:
![screenshot from 2018-09-08 15-29-35](https://user-images.githubusercontent.com/3386440/45257389-03733a80-b37c-11e8-9c3b-cab847cb9539.png)

Como explicado também no commit já citado. Essa mudança causa uma outra diferença no comportamento da função e não capitaliza "palavras" iniciadas em pontuação, por exemplo, a string ".teste" continuaria igual, quando antes da mudança viraria ".Teste", mas acho que isso não é um problema.