### PR TITLE
Resolve issue #21 - Lidar com endereços sem escolas perto

### DIFF
--- a/src/configs/Strings.js
+++ b/src/configs/Strings.js
@@ -31,9 +31,11 @@ export default {
   },
   results: {
     total_wait_message: function (waitListTotal, groupName, numberOfSchools, address) {
+      if (!numberOfSchools) return `Não há creches perto de ${address}.`;
       return `Há ${waitListTotal} crianças na fila do ${groupName} a serem distribuídas nas ${numberOfSchools} creches perto de ${address}.`;
     },
     title_wait_message: function (waitListTotal, numberOfSchools) {
+      if (!numberOfSchools) return `Não há creches próximas a este endereço.`;
       return `Há ${waitListTotal} crianças na fila de espera destas ${numberOfSchools} creches`;
     },
     data_updated_at: function (updatedAt) {

--- a/src/containers/Results/Results.js
+++ b/src/containers/Results/Results.js
@@ -58,7 +58,7 @@ export class Results extends React.Component {
   render() {
     const schoolsNearby = this.state.schoolsNearby ? this.state.schoolsNearby : false;
     const numberOfSchools = this.state.schoolsNearby ? this.state.schoolsNearby.length : false;
-    const waitListTotal = this.state.waitListTotal ? this.state.waitListTotal : 0;
+    const waitListTotal = this.state.waitListTotal ? this.state.waitListTotal : false;
     return (
       <div>
         <BackButton />
@@ -67,9 +67,17 @@ export class Results extends React.Component {
         />}
         {this.state.waitListLoaded && <Banner
           title={STRINGS.results.title_wait_message(waitListTotal, numberOfSchools)}
-          paragraphs={[STRINGS.results.total_wait_message(waitListTotal, this.state.groupName, numberOfSchools, this.state.geocodedAddress), STRINGS.results.data_updated_at(this.state.waitListUpdatedAt), STRINGS.results.see_list_below]}
+          paragraphs={[
+            STRINGS.results.total_wait_message(waitListTotal, this.state.groupName, numberOfSchools, this.state.geocodedAddress),
+            STRINGS.results.data_updated_at(this.state.waitListUpdatedAt),
+            numberOfSchools ? STRINGS.results.see_list_below : null,
+          ]}
         />}
-        {this.state.waitListLoaded && <SchoolList schools={schoolsNearby} groupName={this.state.groupName} groupCode={this.state.groupCode} />}
+        {this.state.waitListLoaded && numberOfSchools ? <SchoolList
+          schools={schoolsNearby}
+          groupName={this.state.groupName}
+          groupCode={this.state.groupCode}
+        /> : null}
         {this.state.waitListLoaded && <Banner
           title={STRINGS.actions.can_do}
         />}

--- a/src/containers/Results/Results.js
+++ b/src/containers/Results/Results.js
@@ -58,7 +58,7 @@ export class Results extends React.Component {
   render() {
     const schoolsNearby = this.state.schoolsNearby ? this.state.schoolsNearby : false;
     const numberOfSchools = this.state.schoolsNearby ? this.state.schoolsNearby.length : false;
-    const waitListTotal = this.state.waitListTotal ? this.state.waitListTotal : false;
+    const waitListTotal = this.state.waitListTotal ? this.state.waitListTotal : 0;
     return (
       <div>
         <BackButton />


### PR DESCRIPTION
O bug relatado nessa issue acontecia quando não haviam escolas na query retornada, o que faz com que `waitListTotal` seja 0, que é "falsy" e dá um comportamento esquisito na comparação do operador ternário. 

Eu não entendo perfeitamente o motivo de fazer essa conversão pro comparador ternário e tenho alguma vontade de refatorar este componente, mas achei uma boa ideia mandar uma solução simples antes de fazer isso.