### PR TITLE
Refatorando Results.js

### DIFF
--- a/src/configs/Strings.js
+++ b/src/configs/Strings.js
@@ -98,7 +98,8 @@ export default {
     start_now: "Comece agora",
     see_on_map: "Ver no mapa",
     call: "Ligar",
-    back: "Voltar"
+    back: "Voltar",
+    loading_error: "Não conseguimos buscar as informações para este endereço, por favor, tente novamente mais tarde",
   },
   messages: {
     month_of_birth: "Mês de nascimento",

--- a/src/containers/Results/Results.js
+++ b/src/containers/Results/Results.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import STRINGS from 'configs/Strings';
-import GLOBALS from 'configs/MainConfigs';
+import findGroupName from 'utils/findGroupName';
 import API from 'configs/Api';
 import { BackButton } from "components/BackButton";
 import { Banner } from "components/Banner";
@@ -13,13 +13,9 @@ import { Spacer } from "components/Spacer";
 export class Results extends React.Component {
   constructor(props) {
     super(props);
-    const groupName = GLOBALS.age_ranges.find(
-      // eslint-disable-next-line eqeqeq
-      o => o.serie == this.props.match.params.groupCode
-    ).dc_serie_ensino;
     this.state = {
       groupCode: this.props.match.params.groupCode,
-      groupName: groupName,
+      groupName: findGroupName(this.props.match.params.groupCode),
       geocodedAddressLng: this.props.match.params.geocodedAddressLng,
       geocodedAddressLat: this.props.match.params.geocodedAddressLat,
       geocodedAddress: this.props.match.params.geocodedAddress,

--- a/src/containers/Results/Results.js
+++ b/src/containers/Results/Results.js
@@ -1,96 +1,75 @@
+import { BackButton } from 'components/BackButton';
+import { Banner } from 'components/Banner';
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { ResultsLoaded } from 'containers/Results/ResultsLoaded';
+import sendAPIRequest from 'utils/sendAPIRequest';
 import STRINGS from 'configs/Strings';
-import findGroupName from 'utils/findGroupName';
-import API from 'configs/Api';
-import { BackButton } from "components/BackButton";
-import { Banner } from "components/Banner";
-import { DefaultButton } from "components/DefaultButton";
-import { ContinueButton } from "components/ContinueButton";
-import { SchoolList } from "./SchoolList";
-import { Spacer } from "components/Spacer";
 
 export class Results extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      groupCode: this.props.match.params.groupCode,
-      groupName: findGroupName(this.props.match.params.groupCode),
-      geocodedAddressLng: this.props.match.params.geocodedAddressLng,
-      geocodedAddressLat: this.props.match.params.geocodedAddressLat,
-      geocodedAddress: this.props.match.params.geocodedAddress,
-      schoolsError: null,
-      schoolsLoaded: false,
-      schoolsNearby: null,
-      waitListLoaded: false,
-      waitListUpdatedAt: null,
-      waitListTotal: null
+      queryResults: {
+        loadState: 'LOADING'
+      }
     };
   }
 
   componentDidMount() {
     window.scrollTo(0, 0);
-
-    let reqUrl = `${API.schools_api_endpoint_wait}/${this.state.geocodedAddressLng}/${this.state.geocodedAddressLat}/${this.state.groupCode}`;
-    fetch(reqUrl)
-      .then(res => res.json())
-      .then(
-        (result) => {
-          this.setState({
-            schoolsLoaded: true,
-            waitListLoaded: true,
-            waitListUpdatedAt: result.results.wait_updated_at,
-            waitListTotal: result.results.wait,
+    sendAPIRequest(
+      this.props.match.params.geocodedAddressLng,
+      this.props.match.params.geocodedAddressLat,
+      this.props.match.params.groupCode,
+    ).then(
+      (result) => {
+        this.setState({
+          queryResults: {
+            loadState: 'OK',
             schoolsNearby: result.results.schools,
-          });
-        },
-        (error) => {
-          this.setState({
-            schoolsLoaded: true,
-            schoolsError: error
-          });
-        }
-      )
-
+            updatedAt: result.results.wait_updated_at,
+            waitListSize: result.results.wait,
+          }
+        });
+        console.log(this.state.queryResults);
+      },
+      (error) => {
+        this.setState({
+          queryResults: {
+            loadState: 'ERROR',
+            loadError: error,
+          }
+        })
+      }
+    )
   }
 
-  render() {
-    const schoolsNearby = this.state.schoolsNearby ? this.state.schoolsNearby : false;
-    const numberOfSchools = this.state.schoolsNearby ? this.state.schoolsNearby.length : false;
-    const waitListTotal = this.state.waitListTotal ? this.state.waitListTotal : false;
+  renderInnerContent () {
+    switch (this.state.queryResults.loadState) {
+      case 'OK':
+        return <ResultsLoaded
+          address={this.props.match.params.geocodedAddress}
+          groupCode={this.props.match.params.groupCode}
+          schoolsNearby={this.state.queryResults.schoolsNearby}
+          updatedAt={this.state.queryResults.updatedAt}
+          waitListSize={this.state.queryResults.waitListSize}
+        />
+      case 'LOADING':
+        return <Banner title={STRINGS.actions.loading_results} />
+      case 'ERROR':
+      default:
+        return <Banner
+          title={STRINGS.actions.loading_error}
+          paragraphs={[this.state.queryResults.error]}
+        />
+    }
+  }
+
+  render () {
     return (
       <div>
         <BackButton />
-        {!this.state.waitListLoaded && <Banner
-          title={STRINGS.actions.loading_results}
-        />}
-        {this.state.waitListLoaded && <Banner
-          title={STRINGS.results.title_wait_message(waitListTotal, numberOfSchools)}
-          paragraphs={[
-            STRINGS.results.total_wait_message(waitListTotal, this.state.groupName, numberOfSchools, this.state.geocodedAddress),
-            STRINGS.results.data_updated_at(this.state.waitListUpdatedAt),
-            numberOfSchools ? STRINGS.results.see_list_below : null,
-          ]}
-        />}
-        {this.state.waitListLoaded && numberOfSchools ? <SchoolList
-          schools={schoolsNearby}
-          groupName={this.state.groupName}
-          groupCode={this.state.groupCode}
-        /> : <Spacer classSize="spacer-sm"/>}
-        {this.state.waitListLoaded && <Banner
-          title={STRINGS.actions.can_do}
-        />}
-        {this.state.waitListLoaded && <Link
-          to={{
-          pathname: STRINGS.routes.register + "/" + this.state.groupCode,
-          state: {
-            schoolsNearby: schoolsNearby
-          }
-        }}>
-          <DefaultButton title={STRINGS.actions.register} subtitle={STRINGS.actions.how_to_register} />
-        </Link>}
-        {this.state.waitListLoaded && <ContinueButton title={STRINGS.actions.compare_address} subtitle={STRINGS.actions.see_wait_near} link={STRINGS.routes.address + "/" + this.state.groupCode} />}
-        {this.state.waitListLoaded && <ContinueButton title={STRINGS.actions.back_to_start} link="/" />}
+        {this.renderInnerContent()}
       </div>
     );
   }

--- a/src/containers/Results/ResultsLoaded.js
+++ b/src/containers/Results/ResultsLoaded.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import STRINGS from 'configs/Strings';
+import { Banner } from 'components/Banner';
+import findGroupName from 'utils/findGroupName';
+import { SchoolList } from 'containers/Results/SchoolList';
+import { Link } from 'react-router-dom';
+import { DefaultButton } from 'components/DefaultButton';
+import { ContinueButton } from 'components/ContinueButton';
+import { Spacer } from 'components/Spacer';
+
+export const ResultsLoaded = (props) => {
+  return (
+    <React.Fragment>
+      <Banner
+        title={STRINGS.results.title_wait_message(
+          props.waitListSize,
+          props.schoolsNearby.length,
+        )}
+        paragraphs={[
+          STRINGS.results.total_wait_message(
+            props.waitListSize,
+            findGroupName(props.groupCode),
+            props.schoolsNearby.length,
+            props.address,
+          ),
+          STRINGS.results.data_updated_at(props.updatedAt),
+          props.schoolsNearby.length ? STRINGS.results.see_list_below : null,
+        ]}
+      />
+      {props.schoolsNearby.length ? <SchoolList
+        schools={props.schoolsNearby}
+        groupName={findGroupName(props.groupCode)}
+        groupCode={props.groupCode}
+      /> : <Spacer
+        classSize="spacer-sm"
+      /> }
+      <Banner title={STRINGS.actions.can_do} />
+      <Link to={{
+        pathname: STRINGS.routes.register + "/" + props.groupCode,
+        state: {schoolsNearby: props.schoolsNearby},
+      }}>
+        <DefaultButton
+          title={STRINGS.actions.register}
+          subtitle={STRINGS.actions.how_to_register}
+        />
+      </Link>
+      <ContinueButton
+        title={STRINGS.actions.compare_address}
+        subtitle={STRINGS.actions.see_wait_near}
+        link={STRINGS.routes.address + "/" + props.groupCode}
+      />
+      <ContinueButton title={STRINGS.actions.back_to_start} link="/" />
+    </React.Fragment>
+  );
+}
+
+ResultsLoaded.propTypes = {
+  address: PropTypes.string,
+  groupCode: PropTypes.string,
+  schoolsNearby: PropTypes.arrayOf(PropTypes.object),
+  updatedAt: PropTypes.string,
+  waitListSize: PropTypes.number,
+};

--- a/src/utils/findGroupName.js
+++ b/src/utils/findGroupName.js
@@ -1,0 +1,8 @@
+import GLOBALS from 'configs/MainConfigs';
+
+export default function findGroupName (groupCode) {
+  return GLOBALS.age_ranges.find(
+    // eslint-disable-next-line eqeqeq
+    o => o.serie == groupCode,
+  ).dc_serie_ensino;
+}

--- a/src/utils/findGroupName.test.js
+++ b/src/utils/findGroupName.test.js
@@ -1,0 +1,5 @@
+import findGroupName from './findGroupName';
+
+test('Finds the group name given a valid groupCode', () => {
+  expect(findGroupName("27")).toEqual("Mini Grupo I");
+});

--- a/src/utils/sendAPIRequest.js
+++ b/src/utils/sendAPIRequest.js
@@ -1,0 +1,7 @@
+import API from 'configs/Api';
+
+export default function sendAPIRequest(longitude, latitude, groupCode) {
+  return fetch(
+    `${API.schools_api_endpoint_wait}/${longitude}/${latitude}/${groupCode}`
+  ).then(res => res.json());
+}


### PR DESCRIPTION
Nada como uma boa refatoração de 140 linhas. Eu basicamente mandei toda a lógica de `Results.js` para dentro de `ResultsLoaded.js` e separei todas as checagens de `waitListLoaded` pra uma só. Se a informação não tá carregada, nem tenta carregar o componente, mostra uma informação diferente.
O comportamento final não muda, exceto pelo tratamento de erro, que não acontecia.

Eu também acho legal fazer assim porque a informação necessária para realmente renderizar a página fica clara: são as props passadas para `ResultsLoaded`. A gente também evita ficar mexendo com estado, porque estado é confuso e dá a impressão de que a página realmente vai ser dinâmica, mas ela não é, a única parte dinâmica é a do load e agora ela tá separada.