### PR TITLE
Remoção da classe que define o tamanho dos ícones

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -121,9 +121,6 @@ a {
 .icons:hover {
   color: #852eb9;
 }
-.icons-lg {
-  font-size: 2em;
-}
 .icons-div {
   margin: 15px 0;
 }

--- a/src/components/DefaultButton.js
+++ b/src/components/DefaultButton.js
@@ -14,7 +14,7 @@ export const DefaultButton = (props) => (
     </div>
     <div className="col-xs-2 no-pad">
       <span className="pull-right">
-        <FontAwesomeIcon icon="chevron-right" size="lg" className="icons icons-lg" />
+        <FontAwesomeIcon icon="chevron-right" size="2x" className="icons" />
       </span>
     </div>
   </div>

--- a/src/components/SchoolContact.js
+++ b/src/components/SchoolContact.js
@@ -14,12 +14,12 @@ export const SchoolContact = ({school}) => (
   <React.Fragment>
     {school.telefones && <div className="icon-div">
       <a href={"tel:" + school.telefones[0]}>
-        <p className="text-center"><FontAwesomeIcon icon="phone" size="lg" className="icons icons-lg" /><br />{STRINGS.actions.call}</p>
+        <p className="text-center"><FontAwesomeIcon icon="phone" size="2x" /><br />{STRINGS.actions.call}</p>
       </a>
     </div>}
     <div className="icons-div">
       <a href={"https://www.google.com/maps/search/?api=1&query=" + school.endereco_completo + " " + GLOBALS.city_state} target="_blank">
-        <p className="text-center"><FontAwesomeIcon icon="map-marker-alt" size="lg" className="icons icons-lg" /><br />{STRINGS.actions.see_on_map}</p>
+        <p className="text-center"><FontAwesomeIcon icon="map-marker-alt" size="2x" className="icons" /><br />{STRINGS.actions.see_on_map}</p>
       </a>
     </div>
   </React.Fragment>

--- a/src/components/SchoolContact.js
+++ b/src/components/SchoolContact.js
@@ -14,7 +14,7 @@ export const SchoolContact = ({school}) => (
   <React.Fragment>
     {school.telefones && <div className="icon-div">
       <a href={"tel:" + school.telefones[0]}>
-        <p className="text-center"><FontAwesomeIcon icon="phone" size="2x" /><br />{STRINGS.actions.call}</p>
+        <p className="text-center"><FontAwesomeIcon icon="phone" size="2x" className="icons" /><br />{STRINGS.actions.call}</p>
       </a>
     </div>}
     <div className="icons-div">


### PR DESCRIPTION
Os ícones inseridos nos componentes DefaultButton e SchoolContact utilizavam a classe "icons-lg" para configurar o tamanho da fonte para 2em. Entretanto é possível fazer essa configuração por meio da propriedade size do componente FontAwesomeIcon. Assim, alterei para utilizar essa propriedade e removi o estilo definido na classe "icons-lg" no arquivo App.css (já que essa classe não é mais utilizada em nenhum outro local).