### PR TITLE
Transformando "NotFound" em um componente funcional.

### DIFF
--- a/src/components/NotFound.js
+++ b/src/components/NotFound.js
@@ -1,18 +1,18 @@
 import React from 'react';
-import { Banner } from "components/Banner";
+import { Banner } from 'components/Banner';
 import { ContinueButton } from 'components/ContinueButton';
 import STRINGS from 'configs/Strings';
 
-export class NotFound extends React.Component {
-  render() {
-    return (
-      <div>
-        <Banner
-          title={STRINGS.not_found.title}
-          paragraphs={[STRINGS.not_found.subtitle]}
-        />
-        <ContinueButton title={STRINGS.actions.back_to_start} subtitle='' link='/' />
-      </div>
-    );
-  }
-}
+export const NotFound = () => (
+  <div>
+    <Banner
+      title={STRINGS.not_found.title}
+      paragraphs={[STRINGS.not_found.subtitle]}
+    />
+    <ContinueButton
+      title={STRINGS.actions.back_to_start}
+      subtitle=""
+      link="/"
+    />
+  </div>
+);


### PR DESCRIPTION
O componente `NotFound` era uma classe sem necessidade, uma vez que não possuia estado. Essa PR apenas converte ele para um componente funcional.